### PR TITLE
Add osx pl translations

### DIFF
--- a/pages.pl/osx/xsand.md
+++ b/pages.pl/osx/xsand.md
@@ -1,0 +1,9 @@
+# xsand
+
+> Demon zarządzający systemem plików Xsan. Zapewnia usługi dla systemu plików Xsan.
+> Nie powinien być wywoływany ręcznie.
+> Więcej informacji: <https://developer.apple.com/support/downloads/Xsan-Management-Guide.pdf>.
+
+- Uruchom demona:
+
+`xsand`

--- a/pages.pl/osx/xsltproc.md
+++ b/pages.pl/osx/xsltproc.md
@@ -1,0 +1,12 @@
+# xsltproc
+
+> Przekształcanie XML z XSLT w celu uzyskania wyjścia (zwykle HTML lub XML).
+> Więcej informacji: <http://www.xmlsoft.org/xslt/xsltproc.html>.
+
+- Przekształcenie pliku XML za pomocą określonego arkusza stylów XSLT:
+
+`xsltproc --output {{sciezka/do/pliku_wyjscia.html}} {{sciezka/do/arkusza_stylow.xslt}} {{sciezka/do/pliku.xml}}`
+
+- Przekaż wartość do parametru w arkuszu stylów:
+
+`xsltproc --output {{sciezka/do/pliku_wyjscia.html}} --stringparam "{{nazwa}}" "{{wartosc}}" {{sciezka/do/arkusza_stylow.xslt}} {{sciezka/do/pliku.xml}}`

--- a/pages.pl/osx/yaa.md
+++ b/pages.pl/osx/yaa.md
@@ -1,0 +1,28 @@
+# yaa
+
+> Tworzenie archiwów YAA i manipulowanie nimi.
+> Więcej informacji: <https://keith.github.io/xcode-man-pages/yaa.1.html>.
+
+- Tworzenie archiwum z katalogu:
+
+`yaa archive -d {{sciezka/do/katalogu}} -o {{sciezka/do/pliku_wyjscia.yaa}}`
+
+- Tworzenie archiwum z pliku:
+
+`yaa archive -i {{sciezka/do/pliku}} -o {{sciezka/do/pliku_wyjscia.yaa}}`
+
+- Wypakowanie archiwum do obecnego folderu:
+
+`yaa extract -i {{sciezka/do/pliku_archiwum.yaa}}`
+
+- Lista zawartości archiwum:
+
+`yaa list -i {{sciezka/do/pliku_wyjscia.yaa}}`
+
+- Tworzenie archiwum z określonym algorytmem kompresji:
+
+`yaa archive -a {{algorytm}} -d {{sciezka/do/folderu}} -o {{sciezka/do/pliku_wyjscia.yaa}}`
+
+- Utwórz archiwum o rozmiarze bloku 8 MB:
+
+`yaa archive -b {{8m}} -d {{sciezka/do/folderu}} -o {{sciezka/do/pliku_wyjscia.yaa}}`

--- a/pages.pl/osx/yaa.md
+++ b/pages.pl/osx/yaa.md
@@ -17,7 +17,7 @@
 
 - Lista zawartości archiwum:
 
-`yaa list -i {{sciezka/do/pliku_wyjscia.yaa}}`
+`yaa list -i {{sciezka/do/pliku_archiwum.yaa}}`
 
 - Tworzenie archiwum z określonym algorytmem kompresji:
 

--- a/pages.pl/osx/yabai.md
+++ b/pages.pl/osx/yabai.md
@@ -1,0 +1,24 @@
+# yabai
+
+> Kafelkowy menedżer okien dla macOS oparty na partycjonowaniu przestrzeni binarnej.
+> Więcej informacji: <https://github.com/koekeishiya/yabai/wiki>.
+
+- Wyślij wiado[m]ość konfiguracyjną w celu ustawienia układu:
+
+`yabai -m config layout {{bsp|stack|float}}`
+
+- Ustaw odstęp między oknami w pt:
+
+`yabai -m config window_gap {{10}}`
+
+- Włącz nieprzezroczystość:
+
+`yabai -m config window_opacity on`
+
+- Wyłącz cienie okien:
+
+`yabai -m config window_shadow off`
+
+- Włącz pasek stanu:
+
+`yabai -m config status_bar on`


### PR DESCRIPTION
This PR adds Polish translations for `xsand`, `xsltproc`, `yaa`, `yabai`. Please review and merge these changes. Thank you.
<!--
Thank you for contributing!
Please fill in the following checklist, removing items that do not apply.
See also https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
-->

- [x] The page(s) are in the correct platform directories: `common`, `linux`, `osx`, `windows`, `sunos`, `android`, etc.
- [x] The page(s) have at most 8 examples.
- [x] The page description(s) have links to documentation or a homepage.
- [x] The page(s) follow the [content guidelines](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#guidelines).
- [x] The PR title conforms to the recommended [templates](/tldr-pages/tldr/blob/main/CONTRIBUTING.md#commit-message-and-pr-title).
